### PR TITLE
Expose Lbfgs to the crate root to show the description of Lbfgs

### DIFF
--- a/src/lbfgs.rs
+++ b/src/lbfgs.rs
@@ -604,12 +604,12 @@ impl Orthantwise {
 // orthantwise:1 ends here
 
 // [[file:../lbfgs.note::*builder][builder:1]]
+/// LBFGS optimizer.
 #[derive(Default, Debug, Clone)]
 pub struct Lbfgs {
     param: LbfgsParam,
 }
 
-/// Create lbfgs optimizer with epsilon convergence
 impl Lbfgs {
     /// Set scaled gradient norm for converence test
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,8 +69,9 @@ pub(crate) mod core {
 // imports:1 ends here
 
 // [[file:~/Workspace/Programming/gosh-rs/lbfgs/lbfgs.note::*lbfgs][lbfgs:1]]
-use crate::lbfgs::Lbfgs;
+pub use crate::lbfgs::Lbfgs;
 
+/// Create a default LBFGS optimizer.
 pub fn lbfgs() -> Lbfgs {
     Lbfgs::default()
 }


### PR DESCRIPTION
## Before
The description of `Lbfgs` does not exist in the document.
<img width="448" alt="Screenshot 2022-08-09 at 12 45 40" src="https://user-images.githubusercontent.com/2175479/183559743-20c81fec-4e9b-46ac-a148-a65591b6f517.png">

## After
<img width="891" alt="Screenshot 2022-08-09 at 12 44 58" src="https://user-images.githubusercontent.com/2175479/183559753-25e47f56-b99f-416c-b51e-be32fb27f684.png">
: